### PR TITLE
Error message bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maap-jupyterlab/dps-jupyter-extension",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A JupyterLab extension for submitting and viewing jobs.",
   "keywords": [
     "dps",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maap-jupyterlab/dps-jupyter-extension",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "A JupyterLab extension for submitting and viewing jobs.",
   "keywords": [
     "dps",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maap-jupyterlab/dps-jupyter-extension",
-  "version": "0.4.1",
+  "version": "0.4.5",
   "description": "A JupyterLab extension for submitting and viewing jobs.",
   "keywords": [
     "dps",
@@ -72,7 +72,7 @@
     "react-paginate": "^8.1.3",
     "react-redux": "^8.0.2",
     "react-select": "^5.4.0",
-    "react-split-pane": "^0.1.92",
+    "react-split-pane": "^2.0.0",
     "react-table": "^7.8.0"
   },
   "devDependencies": {

--- a/src/components/JobSubmissionForm.tsx
+++ b/src/components/JobSubmissionForm.tsx
@@ -110,7 +110,7 @@ export const JobSubmissionForm = () => {
                 let msg = " Job submitted successfully. " + data['response']
                 Notification.success(msg, { autoClose: false })
             }).catch(error => {
-                Notification.error(error, { autoClose: false })
+                Notification.error(error.message, { autoClose: false })
             })
 
             // Refresh job list once job has been submitted

--- a/src/components/JobsView.tsx
+++ b/src/components/JobsView.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import SplitPane, { Pane } from 'react-split-pane'
+import SplitPane from 'react-split-pane'
+import Pane from 'react-split-pane'
 import { JobDetailsContainer } from './JobDetailsContainer'
 import { JobsOverviewContainer } from './JobsOverviewContainer'
 import { JobsContainerActions } from '../redux/slices/JobsContainerSlice'
@@ -17,7 +18,7 @@ export const JobsView = (): JSX.Element => {
     }
 
     return (
-        <SplitPane defaultSize={"60%"} split="horizontal" className="split-pane" onDragFinished={(size) => handleDragFinish(size)}>
+        <SplitPane defaultSize={"60%"} split="horizontal" className="split-pane" onChange={(size) => handleDragFinish(size)}>
             <Pane >
                 <JobsOverviewContainer />
             </Pane>

--- a/src/components/JobsView.tsx
+++ b/src/components/JobsView.tsx
@@ -19,10 +19,10 @@ export const JobsView = (): JSX.Element => {
 
     return (
         <SplitPane defaultSize={"60%"} split="horizontal" className="split-pane" onChange={(size) => handleDragFinish(size)}>
-            <Pane >
+            <Pane defaultSize={"100%"}>
                 <JobsOverviewContainer />
             </Pane>
-            <Pane>
+            <Pane defaultSize={"100%"}>
                 <JobDetailsContainer />
             </Pane>
         </SplitPane>

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -114,3 +114,13 @@ export async function getUsernameToken(state: IStateDB, profileId: string, callb
 
 
 }
+
+
+// Copies jupyter notebook command to user clipboard
+export async function copyNotebookCommand(text: string) {
+    try {
+        await navigator.clipboard.writeText(text).then(() => {INotification.success("Copied Jupyter Notebook python command to clipboard.", { autoClose: false })})
+    } catch (error) {
+        console.warn('Copy failed', error)
+    }
+}


### PR DESCRIPTION
Bug was:
If you tried to submit an invalid job, would get an error in the console `r.split is not a function` and no notification would appear. Then when you tried to select the Notifications icon in the bottom right corner, you couldn't open it and these errors would appear in the console:
<img width="275" alt="Screenshot 2023-07-11 at 2 29 06 PM" src="https://github.com/MAAP-Project/dps-jupyter-extension/assets/114033465/561838f7-a61f-4046-aa9c-b127b3e3e2d8">

I fixed this bug. The behavior when I submit my failing sample job is now:
<img width="1665" alt="Screenshot 2023-07-11 at 2 30 11 PM" src="https://github.com/MAAP-Project/dps-jupyter-extension/assets/114033465/b6cbc760-8bb2-4968-860f-d4827950bbe5">


I wasn't able to locally build this with the package.json as is, so I had to increase the version of react-split-pane to 2.0.0 to get it to run. This caused some breaking changes so I had to change the imports for JobsView, and now the onDragFinished function doesn't take in the size component, so I changed it to use the onChange function which does use a size component
I also needed to add the defaultSize={100%} to both the Pane elements because otherwise the extension looked like this when you first clicked it:
<img width="600" alt="Screenshot 2023-07-11 at 2 26 11 PM" src="https://github.com/MAAP-Project/dps-jupyter-extension/assets/114033465/e712cd20-bf35-4e90-bec0-6e5f3ac6a4b6">

I was using the same version of node as Marjorie (v18.16.0), so I am not sure how the package.json was building before. Marjorie if you don't want to make these changes to the package.json, you could always locally build and deploy with the one  bug fix in this which is changing `error` to `error.message`

If you would like to test this, I have it deployed as an npm package, @maap-jupyterlab/dps-jupyter-extension@0.4.6. I also built an image with this being installed in the jupyterlab3 dockerfile and you can test that image in DIT with this tag: `dps-notifications`