### PR TITLE
Feature/button disable after click

### DIFF
--- a/src/components/JobSubmissionForm.tsx
+++ b/src/components/JobSubmissionForm.tsx
@@ -179,6 +179,8 @@ export const JobSubmissionForm = ({ uname }) => {
             enableSubmitButton();
             setSubmittedJobText(false, null, formValidation);
         }
+        /*const activeElement = document.activeElement as HTMLElement | null;
+        if (activeElement) activeElement.blur();*/
     }
 
     const validateForm = (params) => {
@@ -210,7 +212,8 @@ export const JobSubmissionForm = ({ uname }) => {
         if (switchIsChecked) {
             dispatch(toggleValue())
         }
-
+        const activeElement = document.activeElement as HTMLElement | null;
+        if (activeElement) activeElement.blur();
     }
 
     // Build job submission jupyter notebook command from user-provided selections
@@ -257,6 +260,8 @@ export const JobSubmissionForm = ({ uname }) => {
                   "queue=\"" + jobParams.queue + "\",\n    " + inputStr + ")"
 
         setCommand(tmp)
+        const activeElement = document.activeElement as HTMLElement | null;
+        if (activeElement) activeElement.blur();
     }
     
     return (

--- a/src/components/JobSubmissionForm.tsx
+++ b/src/components/JobSubmissionForm.tsx
@@ -179,8 +179,6 @@ export const JobSubmissionForm = ({ uname }) => {
             enableSubmitButton();
             setSubmittedJobText(false, null, formValidation);
         }
-        /*const activeElement = document.activeElement as HTMLElement | null;
-        if (activeElement) activeElement.blur();*/
     }
 
     const validateForm = (params) => {


### PR DESCRIPTION
Currently, when you click "Clear" or "Copy as Jupyter Notebook Code" on the submit jobs page, the button stays grayed out after clicking it and you have to click somewhere else on the screen to enable it again 
<img width="837" alt="Screenshot 2024-01-31 at 1 29 50 PM" src="https://github.com/MAAP-Project/dps-jupyter-extension/assets/114033465/6f86b662-6528-4817-ac0b-b845bf749bc0">

This enables the button right away to avoid that 

Can test with this image: mas.dit.maap-project.org/root/maap-workspaces/jupyterlab3/vanilla:maap-py-deps