### PR TITLE
Implemented OGC cancel job execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maap-dps-jupyter-extension",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "A JupyterLab extension for submitting and viewing jobs.",
   "keywords": [
     "dps",

--- a/src/components/ViewJobs/ViewJobs.tsx
+++ b/src/components/ViewJobs/ViewJobs.tsx
@@ -146,7 +146,7 @@ export const ViewJobs = ({ app }: ViewJobsProps): JSX.Element => {
           if (result) {
             setSelectedJobResults(result);
           }
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (error: any) {
           console.error('Failed to fetch results for selected job: ', error);
           const message = error?.detail || JSON.stringify(error);
@@ -319,7 +319,7 @@ export const ViewJobs = ({ app }: ViewJobsProps): JSX.Element => {
     try {
       await api.cancelExecution(jobID);
       Notification.success(`Submitted request to cancel job ${jobID}`, { autoClose: false });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
       console.error('Failed to cancel job: ', error);
       const message = error?.detail || JSON.stringify(error);
@@ -396,10 +396,15 @@ export const ViewJobs = ({ app }: ViewJobsProps): JSX.Element => {
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
                 <h3 style={{ margin: 0 }}>Job Details</h3>
                 {selectedJob && nonterminalJobStatuses.includes(selectedJob.status) ? (
-                  <button className="st-button" onClick={(e) => {
-                    handleCancelJob(selectedJob.jobID);
-                    e.currentTarget.blur();
-                  }}>Cancel Job</button>
+                  <button
+                    className="st-button"
+                    onClick={(e) => {
+                      handleCancelJob(selectedJob.jobID);
+                      e.currentTarget.blur();
+                    }}
+                  >
+                    Cancel Job
+                  </button>
                 ) : null}
               </Box>
               <IconButton size="small" onClick={() => setSelectedJob(null)} sx={{ color: '#666' }}>

--- a/src/components/ViewJobs/ViewJobs.tsx
+++ b/src/components/ViewJobs/ViewJobs.tsx
@@ -146,10 +146,11 @@ export const ViewJobs = ({ app }: ViewJobsProps): JSX.Element => {
           if (result) {
             setSelectedJobResults(result);
           }
-        } catch (error) {
-          const message = `Failed to fetch job results: ${error}`;
-          console.error(message);
-          Notification.error(message, { autoClose: false });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (error: any) {
+          console.error('Failed to fetch results for selected job: ', error);
+          const message = error?.detail || JSON.stringify(error);
+          Notification.error(`${message}`, { autoClose: false });
         } finally {
           setLoadingJobResults(false);
         }
@@ -188,6 +189,7 @@ export const ViewJobs = ({ app }: ViewJobsProps): JSX.Element => {
             running: 'info',
             queued: 'warning',
             accepted: 'warning',
+            dismissed: 'secondary',
           };
           const color = statusColors[status?.toLowerCase()] || 'default';
           return (
@@ -313,10 +315,17 @@ export const ViewJobs = ({ app }: ViewJobsProps): JSX.Element => {
     }
   };
 
-  // TODO: API endpoint needs to be updated
-  // const handleCancelJob = async (jobID: string) => {
-  //   const response = await api.cancelExecution(jobID);
-  // };
+  const handleCancelJob = async (jobID: string) => {
+    try {
+      await api.cancelExecution(jobID);
+      Notification.success(`Submitted request to cancel job ${jobID}`, { autoClose: false });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (error: any) {
+      console.error('Failed to cancel job: ', error);
+      const message = error?.detail || JSON.stringify(error);
+      Notification.error(`Failed to cancel job ${jobID}: ${message}`, { autoClose: false });
+    }
+  };
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async function navigateToFolder(outputObj: any[]): Promise<void> {
@@ -384,15 +393,15 @@ export const ViewJobs = ({ app }: ViewJobsProps): JSX.Element => {
                 alignItems: 'center',
               }}
             >
-              <h3 style={{ margin: 0 }}>Job Details</h3>
-              {/* {selectedJob && !cancelableStatuses.includes(selectedJob.status) ? (
-            <button className="st-button" onClick={(e) => {
-                console.log('testing button');
-                handleCancelJob(selectedJob.jobID)
-                e.currentTarget.blur();
-            }
-              }>Cancel Job</button>
-          ) : null} */}
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+                <h3 style={{ margin: 0 }}>Job Details</h3>
+                {selectedJob && nonterminalJobStatuses.includes(selectedJob.status) ? (
+                  <button className="st-button" onClick={(e) => {
+                    handleCancelJob(selectedJob.jobID);
+                    e.currentTarget.blur();
+                  }}>Cancel Job</button>
+                ) : null}
+              </Box>
               <IconButton size="small" onClick={() => setSelectedJob(null)} sx={{ color: '#666' }}>
                 <CloseIcon />
               </IconButton>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,39 +18,16 @@ export const JUPYTER_EXT = {
 };
 
 /*******************************
- * Jobs Tables
- *******************************/
-
-export const MAX_CELL_WIDTH = 350;
-
-export const STYLE_TYPE = {
-  CODE: 'code',
-  TEXT: 'text',
-  URL: 'url',
-};
-
-export const EMPTY_FIELD_CHAR = '-';
-
-export const SUBMITTING_JOB_TEXT = 'Submitting job...';
-export const SUBMITTED_JOB_SUCCESS = '{TIME}\nJob submitted successfully. {ID}';
-export const SUBMITTED_JOB_FAIL = '{TIME}\nJob submission failed because {ERROR}';
-export const SUBMITTED_JOB_ELEMENT_ID = 'submitting_job_text';
-
-export const JOB_STARTED = 'job-started';
-export const JOB_QUEUED = 'job-queued';
-
-/*******************************
  * MAAP API ENDPOINTS
  *******************************/
 export const MAAP_API_ENDPOINTS = {
-  SUBMIT_JOB: 'api/ogc/processes/{PROCESS_ID}/execution',
-  GET_JOBS: 'api/ogc/jobs',
-  GET_JOB_BY_ID: 'api/ogc/jobs/{JOB_ID}',
-  GET_JOB_RESULTS: 'api/ogc/jobs/{JOB_ID}/results',
-  GET_PROCESSES: 'api/ogc/processes',
-  GET_PROCESS: 'api/ogc/processes/{PROCESS_ID}',
-  GET_RESOURCES: 'api/mas/algorithm/resource',
-  CANCEL_EXECUTION: 'api/dps/job/cancel/{JOB_ID}',
+  JOBS: 'api/ogc/jobs',
+  JOBS_JOBID: 'api/ogc/jobs/{JOB_ID}',
+  JOBS_JOBID_RESULTS: 'api/ogc/jobs/{JOB_ID}/results',
+  PROCESSES: 'api/ogc/processes',
+  PROCESSES_PROCESSID: 'api/ogc/processes/{PROCESS_ID}',
+  PROCESSES_PROCESSID_EXECUTION: 'api/ogc/processes/{PROCESS_ID}/execution',
+  ALGORITHM_RESOURCE: 'api/mas/algorithm/resource',
 };
 
 /*******************************

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -48,7 +48,7 @@ export interface Job {
   jobID: string;
   type: string;
   status: string;
-  processID: number;
+  processID?: number;
 }
 
 export interface JobOverviewResponse extends Job {
@@ -194,8 +194,3 @@ export interface JobResultObj {
   id: string;
   links: LinkObj[];
 }
-
-//TODO: dps/job/cancel/ endpoint currently returns WPS style response, which we want to move away from.
-// export interface CancelExecutionResponse {
-
-// }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -102,7 +102,10 @@ export function createMaapApi(getLatestSettings: GetLatestSettings) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     data: any
   ): Promise<ProcessExecutionSuccessResponse | ProcessExecutionFailureResponse> {
-    const endpoint = MAAP_API_ENDPOINTS.PROCESSES_PROCESSID_EXECUTION.replace('{PROCESS_ID}', processId);
+    const endpoint = MAAP_API_ENDPOINTS.PROCESSES_PROCESSID_EXECUTION.replace(
+      '{PROCESS_ID}',
+      processId
+    );
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const response = await request<any>({
@@ -136,9 +139,7 @@ export function createMaapApi(getLatestSettings: GetLatestSettings) {
     id?: string | number
   ): Promise<ProcessListResponse | ProcessResponse | unknown> {
     try {
-      const endpoint = id
-        ? `${MAAP_API_ENDPOINTS.PROCESSES}/${id}`
-        : MAAP_API_ENDPOINTS.PROCESSES;
+      const endpoint = id ? `${MAAP_API_ENDPOINTS.PROCESSES}/${id}` : MAAP_API_ENDPOINTS.PROCESSES;
 
       if (id) {
         return await request<ProcessResponse>({

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -102,7 +102,7 @@ export function createMaapApi(getLatestSettings: GetLatestSettings) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     data: any
   ): Promise<ProcessExecutionSuccessResponse | ProcessExecutionFailureResponse> {
-    const endpoint = MAAP_API_ENDPOINTS.SUBMIT_JOB.replace('{PROCESS_ID}', processId);
+    const endpoint = MAAP_API_ENDPOINTS.PROCESSES_PROCESSID_EXECUTION.replace('{PROCESS_ID}', processId);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const response = await request<any>({
@@ -137,8 +137,8 @@ export function createMaapApi(getLatestSettings: GetLatestSettings) {
   ): Promise<ProcessListResponse | ProcessResponse | unknown> {
     try {
       const endpoint = id
-        ? `${MAAP_API_ENDPOINTS.GET_PROCESSES}/${id}`
-        : MAAP_API_ENDPOINTS.GET_PROCESSES;
+        ? `${MAAP_API_ENDPOINTS.PROCESSES}/${id}`
+        : MAAP_API_ENDPOINTS.PROCESSES;
 
       if (id) {
         return await request<ProcessResponse>({
@@ -168,7 +168,7 @@ export function createMaapApi(getLatestSettings: GetLatestSettings) {
   async function fetchJobs(params: Record<string, string> = {}): Promise<any> {
     const searchParams = new URLSearchParams(params);
     const queryString = searchParams.toString();
-    const endpoint = MAAP_API_ENDPOINTS.GET_JOBS + (queryString ? `?${queryString}` : '');
+    const endpoint = MAAP_API_ENDPOINTS.JOBS + (queryString ? `?${queryString}` : '');
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return await request<any>({
@@ -191,7 +191,7 @@ export function createMaapApi(getLatestSettings: GetLatestSettings) {
     const searchParams = new URLSearchParams(params);
     const queryString = searchParams.toString();
     const endpoint =
-      MAAP_API_ENDPOINTS.GET_JOB_BY_ID.replace('{JOB_ID}', jobId) +
+      MAAP_API_ENDPOINTS.JOBS_JOBID.replace('{JOB_ID}', jobId) +
       (queryString ? `?${queryString}` : '');
 
     return await request<JobResponse>({
@@ -207,7 +207,7 @@ export function createMaapApi(getLatestSettings: GetLatestSettings) {
    * @returns
    */
   async function fetchJobResults(jobId: string): Promise<JobResultResponse> {
-    const endpoint = MAAP_API_ENDPOINTS.GET_JOB_RESULTS.replace('{JOB_ID}', jobId);
+    const endpoint = MAAP_API_ENDPOINTS.JOBS_JOBID_RESULTS.replace('{JOB_ID}', jobId);
     return await request<JobResultResponse>({
       endpoint,
       method: 'GET',
@@ -220,7 +220,7 @@ export function createMaapApi(getLatestSettings: GetLatestSettings) {
    * @returns Fetch resources
    */
   async function fetchResources(): Promise<ResourceResponse | unknown> {
-    const endpoint = MAAP_API_ENDPOINTS.GET_RESOURCES;
+    const endpoint = MAAP_API_ENDPOINTS.ALGORITHM_RESOURCE;
     return await request<ResourceResponse>({
       endpoint,
       method: 'GET',
@@ -233,16 +233,15 @@ export function createMaapApi(getLatestSettings: GetLatestSettings) {
    * @param jobId
    * @returns
    */
-  // TODO: update response type
   async function cancelExecution(
     jobId: string
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): Promise<any | unknown> {
-    const endpoint = MAAP_API_ENDPOINTS.CANCEL_EXECUTION.replace('{JOB_ID}', jobId);
+    const endpoint = MAAP_API_ENDPOINTS.JOBS_JOBID.replace('{JOB_ID}', jobId);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return await request<any>({
       endpoint,
-      method: 'POST',
+      method: 'DELETE',
       auth: true,
     });
   }


### PR DESCRIPTION
Implemented the OGC-compliant cancel job execution feature. For jobs that have a nonterminal job status (i.e. accepted, queued, running), a 'Cancel Job' button will be displayed in the job details panel, allowing users to submit a request for cancellation. Jobs that are cancelled in this way will then be assigned the status of `dismissed` in the UI.

Closes #33 